### PR TITLE
:ambulance: fix maximum call stack exceeded

### DIFF
--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -55,17 +55,17 @@ const Home = () => {
     return;
   }, [submitSuccess, stravaFailed, stravaSuccess])
 
-  const deleteFile = (key) => {
-    let fileList = {}
-    let fileInput = document.getElementById('file-input');
-    fileInput.value = ''
-    Object.assign(fileList, {...garminFiles});
-    
-    delete fileList[key]
-    setGarminFiles(fileList);
-  }
 
   useEffect(() => {
+    const deleteFile = (key) => {
+      let fileList = {}
+      let fileInput = document.getElementById('file-input');
+      fileInput.value = ''
+      Object.assign(fileList, {...garminFiles});
+      
+      delete fileList[key]
+      setGarminFiles(fileList);
+    }
     setGarminFilesError()
 
     if(Object.keys(garminFiles).length < 1)
@@ -85,7 +85,7 @@ const Home = () => {
       )
 
     return;
-  }, [deleteFile, garminFiles])
+  }, [garminFiles])
 
   useEffect(() => {
     const co2perkm = 130 / 1000;


### PR DESCRIPTION
This PR fixes the "maximum update depth exceeded".
As `deleteFile` is only used in the `useEffect`, it's better to simply define it in the useEffect to avoid dependency cycle.

![image](https://user-images.githubusercontent.com/10616972/102134269-93a36280-3e56-11eb-8ab0-cbfbf3e5b4d8.png)
